### PR TITLE
Support more newman option

### DIFF
--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -19,6 +19,8 @@ function GetToolRunner() {
     newman.argIf(typeof reporterHtmlExport != 'undefined' && reporterHtmlExport, ['--reporter-html-export', reporterHtmlExport]);
     let reporterJsonExport = tl.getInput('reporterJsonExport');
     newman.argIf(typeof reporterJsonExport != 'undefined' && reporterJsonExport, ['--reporter-json-export', reporterJsonExport]);
+    let reporterJUnitExport = tl.getPathInput('reporterJUnitExport', false, true);
+    newman.argIf(typeof reporterJUnitExport != 'undefined' && tl.filePathSupplied('reporterJUnitExport'), ['--reporter-junit-export', reporterJUnitExport]);
     let reporters = tl.getInput('reporters');
     newman.argIf(typeof reporters != 'undefined' && reporters, ['-r', reporters]);
 
@@ -30,15 +32,29 @@ function GetToolRunner() {
     newman.argIf(typeof timeoutGlobal != 'undefined' && timeoutGlobal, ['--timeout', timeoutGlobal]);
     let timeoutScript = tl.getInput('timeoutScript', false);
     newman.argIf(typeof timeoutScript != 'undefined' && timeoutScript, ['--timeout-script', timeoutScript]);
-    
+
     let numberOfIterations = tl.getInput('numberOfIterations');
     newman.argIf(typeof numberOfIterations != 'undefined' && numberOfIterations, ['-n', numberOfIterations]);
     let globalVariable = tl.getPathInput('globalVariables', false, true);
     newman.argIf(typeof globalVariable != 'undefined' && tl.filePathSupplied('globalVariables'), ['--globals', globalVariable]);
     let dataFile = tl.getPathInput('dataFile', false, true);
     newman.argIf(typeof globalVariable != 'undefined' && tl.filePathSupplied('dataFile'), ['--iteration-data', dataFile]);
-  
+    let folder = tl.getInput('folder');
+    newman.argIf(typeof folder != 'undefined' && folder, ['--folder', folder]);
+    let globalVars: string[] = tl.getDelimitedInput('globalVars', '\n');
+    globalVars.forEach(globVar => {
+        newman.arg(['--global-var', globVar]);
+    });
+    let ignoreRedirect = tl.getBoolInput('ignoreRedirect');
+    newman.argIf(ignoreRedirect, ['--ignore-redirects']);
     
+    let exportEnvironment = tl.getPathInput('exportEnvironment');
+    newman.argIf(tl.filePathSupplied('exportEnvironment'), ['--export-environment', exportEnvironment]);
+    let exportGlobals = tl.getPathInput('exportGlobals');
+    newman.argIf(tl.filePathSupplied('exportGlobals'), ['--export-globals', exportGlobals]);
+    let exportCollection = tl.getPathInput('exportCollection');
+    newman.argIf(tl.filePathSupplied('exportCollection'), ['--export-collection', exportCollection]);
+
     newman.arg(['-e', tl.getPathInput('environment', true, true)]);
     return newman;
 }

--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -26,11 +26,19 @@ function GetToolRunner() {
     newman.argIf(typeof delayRequest != 'undefined' && delayRequest, ['--delay-request', delayRequest]);
     let timeoutRequest = tl.getInput('timeoutRequest');
     newman.argIf(typeof timeoutRequest != 'undefined' && timeoutRequest, ['--timeout-request', timeoutRequest]);
+    let timeoutGlobal = tl.getInput('timeoutGlobal', false);
+    newman.argIf(typeof timeoutGlobal != 'undefined' && timeoutGlobal, ['--timeout', timeoutGlobal]);
+    let timeoutScript = tl.getInput('timeoutScript', false);
+    newman.argIf(typeof timeoutScript != 'undefined' && timeoutScript, ['--timeout-script', timeoutScript]);
+    
     let numberOfIterations = tl.getInput('numberOfIterations');
     newman.argIf(typeof numberOfIterations != 'undefined' && numberOfIterations, ['-n', numberOfIterations]);
     let globalVariable = tl.getPathInput('globalVariables', false, true);
     newman.argIf(typeof globalVariable != 'undefined' && tl.filePathSupplied('globalVariables'), ['--globals', globalVariable]);
-
+    let dataFile = tl.getPathInput('dataFile', false, true);
+    newman.argIf(typeof globalVariable != 'undefined' && tl.filePathSupplied('dataFile'), ['--iteration-data', dataFile]);
+  
+    
     newman.arg(['-e', tl.getPathInput('environment', true, true)]);
     return newman;
 }

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -33,9 +33,14 @@
             "isExpanded": true
         },
         {
-            "name":"timeout",
-            "displayName":"Timeout Options",
-            "isExpanded":true
+            "name": "timeout",
+            "displayName": "Timeout Options",
+            "isExpanded": true
+        },
+        {
+            "name": "export",
+            "displayName": "Export Options",
+            "isExpanded": false
         }
     ],
     "inputs": [
@@ -56,6 +61,14 @@
             "helpMarkDown": "File paths to include as part of the collection run. Supports multiple lines of match patterns."
         },
         {
+            "name": "folder",
+            "type": "string",
+            "label": "Folder",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Run requests within a particular folder in a collection"
+        },
+        {
             "name": "environment",
             "type": "filePath",
             "label": "Environment",
@@ -70,6 +83,14 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Path to the Postman global variables file as JSON"
+        },
+        {
+            "name": "globalVars",
+            "type": "multiline",
+            "label": "Global Variables",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Global variables to provide to command line in a key=value format. Multiple values can be added."
         },
         {
             "name": "dataFile",
@@ -94,6 +115,14 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Specify a delay (in ms) between requests [number]",
+            "groupName": "requestOptions"
+        },
+        {
+            "name": "ignoreRedirect",
+            "type": "boolean",
+            "label": "Ignore Redirect",
+            "required": false,
+            "helpMarkDown": "Prevents newman from automatically following 3XX redirect responses.",
             "groupName": "requestOptions"
         },
         {
@@ -149,6 +178,15 @@
             "groupName": "report"
         },
         {
+            "name": "reporterJUnitExport",
+            "type": "filePath",
+            "label": "Reporter JUnit Export",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify a path where the output JUnit file will be written to disk. If not specified, the file will be written to newman/ in the current working directory.",
+            "groupName": "report"
+        },
+        {
             "name": "reporters",
             "type": "string",
             "label": "Reporters",
@@ -183,6 +221,33 @@
             "required": false,
             "helpMarkDown": "Specify a request timeout (in ms) for script to complete [number]",
             "groupName": "timeout"
+        },
+        {
+            "name": "exportEnvironment",
+            "type": "filePath",
+            "label": "Export Environment",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify a path where the environment variables file will be output before completing a run",
+            "groupName": "export"
+        },
+        {
+            "name": "exportGlobals",
+            "type": "filePath",
+            "label": "Export Globals",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify a path where the global variable files will be output before completing a run",
+            "groupName": "export"
+        },
+        {
+            "name": "exportCollection",
+            "type": "filePath",
+            "label": "Export Collections",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify a path where the collection file will be output before completing a run",
+            "groupName": "export"
         }
     ],
     "instanceNameFormat": "Newman - Postman",

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -31,6 +31,11 @@
             "name": "ssl",
             "displayName": "SSL Options",
             "isExpanded": true
+        },
+        {
+            "name":"timeout",
+            "displayName":"Timeout Options",
+            "isExpanded":true
         }
     ],
     "inputs": [
@@ -67,6 +72,14 @@
             "helpMarkDown": "Path to the Postman global variables file as JSON"
         },
         {
+            "name": "dataFile",
+            "type": "filePath",
+            "label": "Data",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Path to the data source file as CSV"
+        },
+        {
             "name": "numberOfIterations",
             "type": "string",
             "label": "Number of Iterations",
@@ -81,15 +94,6 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Specify a delay (in ms) between requests [number]",
-            "groupName": "requestOptions"
-        },
-        {
-            "name": "timeoutRequest",
-            "type": "string",
-            "label": "Timeout Request",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "Specify a request timeout (in ms) for a request [number]",
             "groupName": "requestOptions"
         },
         {
@@ -152,6 +156,33 @@
             "required": false,
             "helpMarkDown": "Options include: cli, json, html, and junit. Must be delineated and encapsulated. Ex: 'cli','json' [Learn More](https://github.com/postmanlabs/newman#configuring-reporters)",
             "groupName": "report"
+        },
+        {
+            "name": "timeoutGlobal",
+            "type": "string",
+            "label": "Timeout ",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify entire collection timeout (in ms) to complete [number]",
+            "groupName": "timeout"
+        },
+        {
+            "name": "timeoutRequest",
+            "type": "string",
+            "label": "Timeout Request",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify a request timeout (in ms) for a request [number]",
+            "groupName": "timeout"
+        },
+        {
+            "name": "timeoutScript",
+            "type": "string",
+            "label": "Timeout Script",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify a request timeout (in ms) for script to complete [number]",
+            "groupName": "timeout"
         }
     ],
     "instanceNameFormat": "Newman - Postman",


### PR DESCRIPTION
Added support of :
- `-d <source>` ; source data file
- `--folder <name>` ; specific folder in a collection Run
- `--export-environment`, `--export-globals`, `--export-collection`, export of file after runs
- `--timeout`, `--timeout-request`, `--timeout-script`  : timeout options
- `--ignore-redirects` : option to prevent 3XX redirect follow
-  `--global-var` : to set a var via CLI
-  `--reporter-junit-export` : to relocate Junit report.

Added group in configuration. (feel free to update if necessary)

Just a few more to be supported and it could be stated 'all newman options' supported :-)
Let's hope not too much regression....