### PR TITLE
Removed path check for Junit report output path

### DIFF
--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -36,7 +36,7 @@ function GetToolRunner(collectionToRun: string) {
     newman.argIf(typeof reporterHtmlExport != 'undefined' && tl.filePathSupplied('reporterHtmlExport'), ['--reporter-html-export', reporterHtmlExport]);
     let reporterJsonExport = tl.getPathInput('reporterJsonExport');
     newman.argIf(typeof reporterJsonExport != 'undefined' && tl.filePathSupplied('reporterJsonExport'), ['--reporter-json-export', reporterJsonExport]);
-    let reporterJUnitExport = tl.getPathInput('reporterJUnitExport', false, true);
+    let reporterJUnitExport = tl.getPathInput('reporterJUnitExport', false, false);
     newman.argIf(typeof reporterJUnitExport != 'undefined' && tl.filePathSupplied('reporterJUnitExport'), ['--reporter-junit-export', reporterJUnitExport]);
 
     let reporterList = tl.getInput('reporters');

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 21
+        "Patch": 22
     },
     "demands": [],
     "groups": [{


### PR DESCRIPTION
Removed path check for Junit report output path to avoid having to use a separate task just create an empty directory or xml file, when a custom Junit location is needed.

Should solve #48 