### PR TITLE
Rename sslStrict argument as sslInsecure

### DIFF
--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -21,8 +21,8 @@ function GetToolRunner(collectionToRun: string) {
     newman.argIf(typeof sslClientCert != 'undefined' && tl.filePathSupplied('sslClientCert'), ['--ssl-client-cert', sslClientCert]);
     let sslClientKey = tl.getPathInput('sslClientKey', false, true);
     newman.argIf(typeof sslClientKey != 'undefined' && tl.filePathSupplied('sslClientKey'), ['--ssl-client-key', sslClientKey]);
-    let sslStrict = tl.getBoolInput('sslStrict');
-    newman.argIf(sslStrict, ['--insecure']);
+    let sslInsecure = tl.getBoolInput('sslInsecure');
+    newman.argIf(sslInsecure, ['--insecure']);
 
     let unicodeDisabled = tl.getBoolInput('unicodeDisabled');
     newman.argIf(unicodeDisabled, ['--disable-unicode']);

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -11,9 +11,9 @@
   ],
   "author": "Carlo Wahlstedt",
   "version": {
-    "Major": 3,
+    "Major": 4,
     "Minor": 0,
-    "Patch": 23
+    "Patch": 0
   },
   "demands": [],
   "groups": [
@@ -241,7 +241,7 @@
       "groupName": "ssl"
     },
     {
-      "name": "sslStrict",
+      "name": "sslInsecure",
       "type": "boolean",
       "label": "Disable Strict SSL",
       "helpMarkDown": "Disables strict ssl",

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Following command line options are **not supported**:
 
 ### Breaking change(s) ###
 
-#### Version 4.x
+#### Version 4.x ####
 
 * The `sslStrict` parameter is renamed as `sslInsecure` in order to better match with the actual behavior of the parameter: setting it to `true` will use newman `--insecure` option to disable the strict SSL verification.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Following command line options are **not supported**:
 - `--ssl-client-passphrase`
 - None of the [CLI option](https://github.com/postmanlabs/newman#cli-reporter-options)
 
+### Breaking change(s) ###
+
+#### Version 4.x
+
+* The `sslStrict` parameter is renamed as `sslInsecure` in order to better match with the actual behavior of the parameter: setting it to `true` will use newman `--insecure` option to disable the strict SSL verification.
+
 ### Known issue(s) ###
 
 - None


### PR DESCRIPTION
Rename `sslStrict` to `sslInscure` in order to make the parameter more consistent with its actual behavior, to help with https://github.com/carlowahlstedt/NewmanPostman_VSTS_Task/issues/58.