### PR TITLE
Switch sslStrict behavior

### DIFF
--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -22,7 +22,7 @@ function GetToolRunner(collectionToRun: string) {
     let sslClientKey = tl.getPathInput('sslClientKey', false, true);
     newman.argIf(typeof sslClientKey != 'undefined' && tl.filePathSupplied('sslClientKey'), ['--ssl-client-key', sslClientKey]);
     let sslStrict = tl.getBoolInput('sslStrict');
-    newman.argIf(sslStrict, ['--insecure']);
+    newman.argIf(!sslStrict, ['--insecure']);
 
     let unicodeDisabled = tl.getBoolInput('unicodeDisabled');
     newman.argIf(unicodeDisabled, ['--disable-unicode']);

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -11,9 +11,9 @@
   ],
   "author": "Carlo Wahlstedt",
   "version": {
-    "Major": 3,
+    "Major": 4,
     "Minor": 0,
-    "Patch": 23
+    "Patch": 0
   },
   "demands": [],
   "groups": [
@@ -243,8 +243,9 @@
     {
       "name": "sslStrict",
       "type": "boolean",
-      "label": "Disable Strict SSL",
-      "helpMarkDown": "Disables strict ssl",
+      "label": "Enable Strict SSL",
+      "defaultValue": true,
+      "helpMarkDown": "Enables strict ssl",
       "groupName": "ssl"
     },
     {


### PR DESCRIPTION
Switch `sslStrict` behavior in order to make itmore consistent with its name, to help with https://github.com/carlowahlstedt/NewmanPostman_VSTS_Task/issues/58.