### PR TITLE
Add support for htmlextra console logs 

### DIFF
--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -43,6 +43,8 @@ function GetToolRunner(collectionToRun: string) {
     newman.argIf(typeof reporterHtmlExtraExport != 'undefined' && tl.filePathSupplied('reporterHtmlExtraExport'), ['--reporter-htmlextra-export', reporterHtmlExtraExport]);
     let htmlExtraDarkTheme = tl.getBoolInput('htmlExtraDarkTheme');
     newman.argIf(htmlExtraDarkTheme, ['--reporter-htmlextra-darkTheme']);
+    let htmlExtraLogs = tl.getBoolInput('htmlExtraLogs');
+    newman.argIf(htmlExtraLogs, ['--reporter-htmlextra-logs']);
     let htmlExtraTestPaging = tl.getBoolInput('htmlExtraTestPaging');
     newman.argIf(htmlExtraTestPaging, ['--reporter-htmlextra-testPaging']);
     let htmlExtraReportTitle = tl.getInput('htmlExtraReportTitle');

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -309,6 +309,13 @@
       "groupName": "report"
     },
     {
+      "name": "htmlExtraLogs",
+      "type": "boolean",
+      "label": "Enable HTML Extra Console Logs",
+      "helpMarkDown": "Set this optional flag to enable additional console logs from the reporter.",
+      "groupName": "report"
+    },
+    {
       "name": "htmlExtraTestPaging",
       "type": "boolean",
       "label": "Enable pagination.",


### PR DESCRIPTION
Added console log support via "--reporter-htmlextra-logs" switch. 

https://www.npmjs.com/package/newman-reporter-htmlextra