### PR TITLE
Update README with install of older Newman version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can include this task in a build or release pipeline. Here's a quick 'How To
 
 1. Set `custom` as command
 
-1. As 'Command and arguments' set `install newman -g`
+1. As 'Command and arguments' set `install newman -g`. Note that if the task version doesn't yet support the latest Newman version, an older version can be used, e.g. `install newman@4.6.1 -g`.
 
 ### Execution ###
 


### PR DESCRIPTION
Hi!
My pipeline failed this morning, since Newman 5.0.0 has just been released. I needed to adjust the installer task to use an older version. I thought this info might be useful to others as well.
Kind regards,
Johan