### PR TITLE
Support using collection name as output filename

### DIFF
--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -276,6 +276,15 @@
       "groupName": "report"
     },
     {
+      "name": "useCollectionNameAsFilename",
+      "type": "boolean",
+      "defaultValue": false,
+      "required": false,
+      "label": "Use collection name as filename",
+      "helpMarkDown": "Output files from reporters will have the same name as test collection.",
+      "groupName": "report"
+    },
+    {
       "name": "reporterHtmlTemplate",
       "type": "filePath",
       "label": "Reporter Html Template",


### PR DESCRIPTION
Closes #62 

This adds support to name output files according to collection name. For this, new input parameter for task was added: `useCollectionNameAsFilename`. If this parameter is `true`, collection name is obtained:

- The name is read directly from collection `.json` file.
- If there is no name inside `.json`, the filename itself is used.
- Then invalid filename characters are replaced with dash (`-`).
- I do not care about accented characters. Most file systems can handle them.

### If the obtained collection name is empty

- The task works as before.

### If we have the collection name

- User supplied `export` input argument for given reporter:
  - If the value provided has correct file extension for given reporter, this value is used **as-is**. I assume that user explicitly provided output filename, so I do not want to change it.
  - If the `export` input argument does not have correct extension, it is used as directory, and filename based on collection name is appended to it.
- User did not set `export` input argument for given reporter:
  - Than `newman` is used as the directory, and filename based on collection name is appended to it. This is to keep the default behavior, when output files are written to `newman` folder when nothing is specified. So if user turns on `useCollectionNameAsFilename`, the output files will still be in the same location, just with new names.

The filename is created as `{collection name}-{reporter name}.{extension}`. So if collection name is `Base tests`:

- JUnit reporter output file will be `Base tests-junit.xml`.
- HTML reporter output file will be `Base tests-html.html`.

Reporter name is there not only for clarity (as mentioned in the comment of the issue), but to make filename unique, if both HTML reporters are used.

This change should probably have some tests, but Typescript/Javascript is not _my language_, so I need at least some hint here. I looked at existing tests, but do not understand exactly how they work and what do they really test.