### PR TITLE
Release v4.1.1: bump versions and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## v4.1.1 — task / 3.0.25 — extension
+
+### Fixed
+- Pass the htmlextra template path through with the correct flag and variable. The previous code emitted `--reporter-htmlextra-template ` (trailing space) and forwarded the plain `html` template path instead of the configured `htmlextra` template, so the input was silently ignored. (#99, #117)
+
+## v4.1.0 — task / 3.0.24 — extension
+
+### Changed
+- Migrated the task off the end-of-life Node 6 execution handler to `Node20_1`. Pipelines using `NewmanPostman@4` heal automatically on next run; no YAML changes required. (#101, #110, #111, #115)
+- Modernized the supporting toolchain: `azure-pipelines-task-lib` 2 → 4, TypeScript 2.3 → 5, `@types/node` 8 → 20, mocha 5 → 10, tfx-cli 0.7 → 0.17. (#115)
+- Restored CI: pipeline now runs on `ubuntu-latest`, the previously-disabled `npm test` step gates the build, and `TfxInstaller@1` was bumped to `v0.17.x` to silence a stderr warning that was failing the package step. (#113)
+
+### Fixed
+- Test scenarios were calling `setInput('environmentFile', ...)` while the actual task input is named `environment`; the suite has been quietly broken in CI for years because `npm test` was commented out. (#113)

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 4,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "NewmanPostman",
-  "version": "3.0.24",
+  "version": "3.0.25",
   "name": "Newman the cli Companion for Postman",
   "scopes": [],
   "description": "Using Newman, one can effortlessly run and test a Postman Collections directly from the command-line. Now in a task! ** Not an official task **",


### PR DESCRIPTION
## Summary

Bumps the task and extension versions for the v4.1.1 release that ships the htmlExtra template fix (#117), and adds a `CHANGELOG.md` capturing v4.1.1 plus the previously-undocumented v4.1.0 (Node 20 migration).

| File | Change |
| --- | --- |
| `NewmanPostman/task.json` | task version `4.1.0` → `4.1.1` |
| `vss-extension.json` | extension version `3.0.24` → `3.0.25` |
| `CHANGELOG.md` | new file with v4.1.1 + v4.1.0 entries |

## After this merges

Run locally:

```bash
npm install && npm run install-task-lib && npm test
npm run package          # produces carlowahlstedt.NewmanPostman-3.0.25.vsix (and bumps to 3.0.26 — revert that)
npm run gallery-publish  # requires your tfx login credentials
```

(Or if you'd rather not have `--rev-version` auto-bumping again, run `npx tfx extension create` directly without that flag.)

Then close issues **#99, #101, #110, #111** with a "fixed in v4.1.1" reference and tag the v4.1.1 GitHub release.

## Draft GitHub release notes (paste into https://github.com/carlowahlstedt/NewmanPostman_VSTS_Task/releases/new)

**Tag:** `v4.1.1`
**Title:** `v4.1.1 — htmlExtra template fix`
**Body:**

> First release after the Node 20 migration in v4.1.0. Pipelines on `NewmanPostman@4` will pick this up automatically on the next run.
>
> ### Fixed
> - htmlExtra template input is now passed through to newman with the correct flag and value. The previous code emitted `--reporter-htmlextra-template ` (trailing space) and forwarded the plain `html` template path instead of the configured `htmlextra` template, so the input was silently ignored. Thanks to @CBR79 for the report. (#99, #117)
>
> ### Heads up — what changed in v4.1.0 (not previously released as a tag)
> - **Node 6 → Node 20.** The `Node` execution handler was end-of-life and the task had been hard-failing on agents that no longer ship Node 6. Migrated to `Node20_1`. (#101, #110, #111, #115)
> - Modernized toolchain: `azure-pipelines-task-lib` 2 → 4, TypeScript 2.3 → 5, mocha 5 → 10, tfx-cli 0.7 → 0.17.
> - CI restored: `azure-pipelines.yml` switched from the retired `Hosted VS2017` pool to `ubuntu-latest`, `npm test` re-enabled to gate the build, `TfxInstaller@1` bumped to `v0.17.x`. Test scenarios using a stale input name (`environmentFile` vs `environment`) were corrected. (#113)
>
> Full changelog in [CHANGELOG.md](https://github.com/carlowahlstedt/NewmanPostman_VSTS_Task/blob/master/CHANGELOG.md).

## Test plan
- [x] `task.json` and `vss-extension.json` versions are coherent.
- [x] `CHANGELOG.md` references the correct PR / issue numbers.
- [ ] CI on this branch passes (no source code changed, so just sanity-checking the JSON edits don't break parsing).

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_