### PR TITLE
Bump deprecated ms-devlabs pipeline tasks to @5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,11 +41,11 @@ stages:
         verbose: false
         customCommand: 'run compile'
 
-    - task: TfxInstaller@1
+    - task: TfxInstaller@5
       inputs:
         version: 'v0.17.x'
 
-    - task: ms-devlabs.vsts-developer-tools-build-tasks.package-extension-build-task.PackageVSTSExtension@1
+    - task: ms-devlabs.vsts-developer-tools-build-tasks.package-extension-build-task.PackageVSTSExtension@5
       displayName: 'Package Extension'
       inputs:
         outputPath: 'drop/output.vsix'
@@ -71,12 +71,12 @@ stages:
       runOnce:
         deploy:
           steps:
-          - task: ms-devlabs.vsts-developer-tools-build-tasks.tfx-installer-build-task.TfxInstaller@3
+          - task: ms-devlabs.vsts-developer-tools-build-tasks.tfx-installer-build-task.TfxInstaller@5
             displayName: 'Use Node CLI for Azure DevOps (tfx-cli): v0.17.x'
             inputs:
               version: 'v0.17.x'
 
-          - task: ms-devlabs.vsts-developer-tools-build-tasks.extension-version-build-task.ExtensionVersion@1
+          - task: ms-devlabs.vsts-developer-tools-build-tasks.extension-version-build-task.ExtensionVersion@5
             displayName: 'Query Extension Version: carlowahlstedt.NewmanPostman'
             inputs:
               connectedServiceName: 'carlowahlstedt-VSTS'
@@ -84,7 +84,7 @@ stages:
               extensionId: NewmanPostman
               versionAction: Patch
 
-          - task: ms-devlabs.vsts-developer-tools-build-tasks.publish-extension-build-task.PublishExtension@1
+          - task: ms-devlabs.vsts-developer-tools-build-tasks.publish-extension-build-task.PublishExtension@5
             displayName: 'Publish Extension'
             inputs:
               connectedServiceName: 'carlowahlstedt-VSTS'


### PR DESCRIPTION
## Summary

Silences the two Node-EOL warnings the Build stage was emitting after #120:

> Task 'Use Node CLI for Azure DevOps (tfx-cli)' version 1 (TfxInstaller@1) is dependent on a Node version (10) that is end-of-life…
>
> Task 'Package Extension' version 1 (PackageVSTSExtension@1) is dependent on a Node version (6) that is end-of-life…

Bumps every `ms-devlabs.vsts-developer-tools-build-tasks` task to `@5` (the major that runs on Node 20). The Publish stage's `@1`/`@3` majors are also pre-Node-20, so they get bumped here too even though they hadn't fired their warning yet (they would when you next approve a publish).

| Task | Before | After |
| --- | --- | --- |
| `TfxInstaller` (build) | `@1` | `@5` |
| `PackageVSTSExtension` (build) | `@1` | `@5` |
| `TfxInstaller` (publish) | `@3` | `@5` |
| `ExtensionVersion` (publish) | `@1` | `@5` |
| `PublishExtension` (publish) | `@1` | `@5` |

`GitHubRelease@1` is the only major Microsoft has published, so that one stays.

## Test plan
- [ ] Build stage no longer surfaces Node-EOL warnings on the Initialize job step.
- [ ] Next approved Publish run still queries / publishes / tags successfully against the existing service connections (`carlowahlstedt-VSTS`, `GitHub connection 1`).

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_