### PR TITLE
Fix Publish Artifact step after PackageVSTSExtension@5 bump

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,13 +48,13 @@ stages:
     - task: ms-devlabs.vsts-developer-tools-build-tasks.package-extension-build-task.PackageVSTSExtension@5
       displayName: 'Package Extension'
       inputs:
-        outputPath: 'drop/output.vsix'
+        outputPath: '$(Build.ArtifactStagingDirectory)/output.vsix'
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: drop'
       condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
       inputs:
-        PathtoPublish: '$(Extension.OutputPath)'
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)/output.vsix'
         ArtifactName: drop
 
 - stage: Publish


### PR DESCRIPTION
## Summary

Fixes the `Publish Artifact: drop` step that's been failing on master since #121:

> ##[error]Publishing build artifacts failed with an error: Not found PathtoPublish: /home/vsts/work/1/s/$(Extension.OutputPath)

`PackageVSTSExtension@5` (introduced in #121) — unlike `@1` — does **not** publish `Extension.OutputPath` as a job-level pipeline variable, so `PublishBuildArtifacts@1` was getting the literal unexpanded `$(Extension.OutputPath)` string and falling through to "path not found".

## Fix

Have the package step write to `$(Build.ArtifactStagingDirectory)/output.vsix` and publish that same path. The artifact name stays `drop`, and the Publish stage still finds it at `$(Pipeline.Workspace)/drop/output.vsix` — so no other step needs to change.

```diff
     - task: PackageVSTSExtension@5
       inputs:
-        outputPath: 'drop/output.vsix'
+        outputPath: '$(Build.ArtifactStagingDirectory)/output.vsix'

     - task: PublishBuildArtifacts@1
       inputs:
-        PathtoPublish: '$(Extension.OutputPath)'
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)/output.vsix'
         ArtifactName: drop
```

## Test plan
- [ ] Build stage's "Publish Artifact: drop" step succeeds.
- [ ] Approved Publish stage still finds the `.vsix` at `$(Pipeline.Workspace)/drop/output.vsix`.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_