### PR TITLE
Set connectTo: VsTeam on @5 marketplace tasks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,7 @@ stages:
           - task: ms-devlabs.vsts-developer-tools-build-tasks.extension-version-build-task.ExtensionVersion@5
             displayName: 'Query Extension Version: carlowahlstedt.NewmanPostman'
             inputs:
+              connectTo: 'VsTeam'
               connectedServiceName: 'carlowahlstedt-VSTS'
               publisherId: carlowahlstedt
               extensionId: NewmanPostman
@@ -87,6 +88,7 @@ stages:
           - task: ms-devlabs.vsts-developer-tools-build-tasks.publish-extension-build-task.PublishExtension@5
             displayName: 'Publish Extension'
             inputs:
+              connectTo: 'VsTeam'
               connectedServiceName: 'carlowahlstedt-VSTS'
               fileType: vsix
               vsixFile: '$(Pipeline.Workspace)/drop/output.vsix'


### PR DESCRIPTION
## Summary

Fixes the `Query Extension Version` step that's been failing on master since the @5 task bumps in #121:

> ##[error]Input required: connectedServiceNameAzureRM

`ExtensionVersion@5` and `PublishExtension@5` introduced a `connectTo` input that toggles between two auth methods:

- `connectTo: 'AzureRM'` (default in @5) — expects a workload-identity service connection in `connectedServiceNameAzureRM`.
- `connectTo: 'VsTeam'` — uses the legacy PAT-based service connection in `connectedServiceName`.

The `carlowahlstedt-VSTS` connection is the latter, so this PR explicitly sets `connectTo: 'VsTeam'` on both tasks.

```diff
       - task: ExtensionVersion@5
         inputs:
+          connectTo: 'VsTeam'
           connectedServiceName: 'carlowahlstedt-VSTS'
           ...

       - task: PublishExtension@5
         inputs:
+          connectTo: 'VsTeam'
           connectedServiceName: 'carlowahlstedt-VSTS'
           ...
```

## Test plan
- [ ] Approved Publish stage's `Query Extension Version` step succeeds.
- [ ] `Publish Extension` step then publishes the `.vsix` to the marketplace.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_