### PR TITLE
Check out repo in deploy job so GitHubRelease can read CHANGELOG.md

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,8 @@ stages:
       runOnce:
         deploy:
           steps:
+          - checkout: self
+
           - task: ms-devlabs.vsts-developer-tools-build-tasks.tfx-installer-build-task.TfxInstaller@5
             displayName: 'Use Node CLI for Azure DevOps (tfx-cli): v0.17.x'
             inputs:


### PR DESCRIPTION
## Summary

The marketplace publish step is now succeeding (badges fixed in #124), but the next step `GitHubRelease@1` is failing:

> ##[error]Error: Not found releaseNotesFilePath: /home/vsts/work/1/s/CHANGELOG.md

**Root cause:** Deployment jobs in YAML pipelines do **not** auto-checkout the source repository — `$(Build.SourcesDirectory)` is empty by default. The Build stage's job did check out the source, but the Publish stage runs as a separate `deployment:` job in a fresh workspace, and `CHANGELOG.md` lives in the repo (not in the build artifact `drop/`, which only contains the `.vsix`).

## Fix

Add `- checkout: self` as the first step of the deploy job. That clones the repo into `$(Build.SourcesDirectory)`, and `GitHubRelease@1` finds `CHANGELOG.md` at the relative path it expects.

```diff
       runOnce:
         deploy:
           steps:
+          - checkout: self
+
           - task: TfxInstaller@5
             ...
```

## Test plan
- [ ] Approved Publish stage's `Create GitHub Release` step succeeds and produces a `vX.Y.Z` tag with the CHANGELOG content as release notes and the `.vsix` attached.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_