### PR TITLE
Fix forceNoColor to emit the supported --color off flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.2 — task / 3.0.26 — extension
+
+### Fixed
+- The `forceNoColor` input now emits `--color off` instead of the removed `--no-color` flag, so newman correctly disables colored CLI output. The previous code silently failed on any newman version released since 2019. (#50)
+
 ## v4.1.1 — task / 3.0.25 — extension
 
 ### Fixed

--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -28,7 +28,7 @@ function GetToolRunner(collectionToRun: string) {
     newman.argIf(unicodeDisabled, ['--disable-unicode']);
 
     let forceNoColor = tl.getBoolInput('forceNoColor');
-    newman.argIf(forceNoColor, ['--no-color']);
+    newman.argIf(forceNoColor, ['--color', 'off']);
 
     let reporterHtmlTemplate = tl.getPathInput('reporterHtmlTemplate', false, true);
     newman.argIf(typeof reporterHtmlTemplate != 'undefined' && tl.filePathSupplied('reporterHtmlTemplate'), ['--reporter-html-template', reporterHtmlTemplate]);

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 4,
     "Minor": 1,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [

--- a/Tests/TestSuite.ts
+++ b/Tests/TestSuite.ts
@@ -191,6 +191,15 @@ describe('Normal behavior', function () {
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--reporter-htmlextra-template ' + path.normalize('/srcDir/htmlExtra.hbs')), 'htmlextra template is added as arg');
     })
+    it('forceNoColor input forwards the supported --color off flag', async () => {
+        this.timeout(1000);
+        let testPath = path.join(__dirname, 'forceNoColorTest.js');
+        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        await runner.runAsync();
+        assert(runner.succeeded, 'Should be in success');
+        assert(runner.stdOutContained('--color off'), 'newman should be invoked with --color off');
+        assert(!runner.stdOutContained('--no-color'), 'the removed --no-color flag should not be emitted');
+    })
 });
 
 

--- a/Tests/forceNoColorTest.ts
+++ b/Tests/forceNoColorTest.ts
@@ -1,0 +1,30 @@
+import mockanswer = require('azure-pipelines-task-lib/mock-answer');
+import mockrun = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'NewmanPostman', 'newmantask.js');
+
+let runner: mockrun.TaskMockRunner = new mockrun.TaskMockRunner(taskPath);
+let filePath = path.normalize('/srcDir/collection.json');
+
+runner.setInput('collectionSourceType', 'file');
+runner.setInput('environmentSourceType', 'none');
+runner.setInput('collectionFileSource', filePath);
+runner.setInput('Contents', path.normalize('**/collection.json'));
+runner.setInput('forceNoColor', 'true');
+
+let answers = <mockanswer.TaskLibAnswers>{
+    'checkPath': {},
+    'which': {
+        'newman': 'newman'
+    },
+    'stats': {},
+    'exec': {}
+};
+answers.checkPath[filePath] = true;
+answers.checkPath['newman'] = true;
+answers.stats[filePath] = true;
+runner.setAnswers(answers);
+
+answers.exec[`newman run ${filePath} --color off`] = { 'code': 0, 'stdout': 'OK' };
+runner.run();

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "NewmanPostman",
-  "version": "3.0.25",
+  "version": "3.0.26",
   "name": "Newman the cli Companion for Postman",
   "scopes": [],
   "description": "Using Newman, one can effortlessly run and test a Postman Collections directly from the command-line. Now in a task! ** Not an official task **",


### PR DESCRIPTION
## Summary

- Newman dropped `--no-color` back in 2018 in favor of `--color {on,off,auto}`. The `forceNoColor` input on this task has been silently a no-op on every modern newman release because the code at `NewmanPostman/newmantask.ts:31` was still emitting `--no-color`.
- Switch to `['--color', 'off']`.
- New `Tests/forceNoColorTest.ts` asserts the new flag is emitted and the removed flag isn't.
- `task.json`: 4.1.1 → 4.1.2 (patch). `vss-extension.json`: 3.0.25 → 3.0.26.
- Adds a CHANGELOG entry.

Closes #50.

## Test plan

- [x] `npm test` — all 20 scenarios pass on Node 20 (19 existing + 1 new).
- [x] New scenario asserts both presence of `--color off` and absence of `--no-color` in the captured stdout.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_