### PR TITLE
Suffix per-collection reporter export filenames in folder mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.2.0 — task / 3.1.0 — extension
+
+### Changed
+- When the task iterates over multiple collections in a folder (via `collectionFileSource` + `Contents`), each per-collection reporter export filename is now suffixed with the collection's base name. For example, `reporterJUnitExport: /out/report.xml` now produces `/out/report-collection1.xml`, `/out/report-collection2.xml`, etc. — so the per-collection results no longer overwrite each other. Single-file runs are unchanged. Affects the html, htmlextra, json, and junit reporter export paths. (#102, #66, #62)
+
 ## v4.1.2 — task / 3.0.26 — extension
 
 ### Fixed

--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -3,7 +3,14 @@ import tl = require('azure-pipelines-task-lib/task');
 import trm = require('azure-pipelines-task-lib/toolrunner');
 import isurl = require('is-url');
 
-function GetToolRunner(collectionToRun: string) {
+function suffixExportPath(p: string | undefined, suffix: string | undefined): string | undefined {
+    if (!p || !suffix) return p;
+    const parsed = path.parse(p);
+    if (!parsed.ext || !parsed.name) return p;
+    return path.join(parsed.dir, `${parsed.name}-${suffix}${parsed.ext}`);
+}
+
+function GetToolRunner(collectionToRun: string, exportSuffix?: string) {
     let pathToNewman = tl.getInput('pathToNewman', false);
     if (typeof pathToNewman != 'undefined' && pathToNewman) {
         console.info("Specific path to newman found");
@@ -32,14 +39,14 @@ function GetToolRunner(collectionToRun: string) {
 
     let reporterHtmlTemplate = tl.getPathInput('reporterHtmlTemplate', false, true);
     newman.argIf(typeof reporterHtmlTemplate != 'undefined' && tl.filePathSupplied('reporterHtmlTemplate'), ['--reporter-html-template', reporterHtmlTemplate]);
-    let reporterHtmlExport = tl.getPathInput('reporterHtmlExport');
+    let reporterHtmlExport = suffixExportPath(tl.getPathInput('reporterHtmlExport'), exportSuffix);
     newman.argIf(typeof reporterHtmlExport != 'undefined' && tl.filePathSupplied('reporterHtmlExport'), ['--reporter-html-export', reporterHtmlExport]);
     /**
     * Items for HTML extra https://www.npmjs.com/package/newman-reporter-htmlextra.
     */
     let reporterHtmlExtraTemplate = tl.getPathInput('reporterHtmlExtraTemplate', false, true);
     newman.argIf(typeof reporterHtmlExtraTemplate != 'undefined' && tl.filePathSupplied('reporterHtmlExtraTemplate'), ['--reporter-htmlextra-template', reporterHtmlExtraTemplate]);
-    let reporterHtmlExtraExport = tl.getPathInput('reporterHtmlExtraExport');
+    let reporterHtmlExtraExport = suffixExportPath(tl.getPathInput('reporterHtmlExtraExport'), exportSuffix);
     newman.argIf(typeof reporterHtmlExtraExport != 'undefined' && tl.filePathSupplied('reporterHtmlExtraExport'), ['--reporter-htmlextra-export', reporterHtmlExtraExport]);
     let htmlExtraDarkTheme = tl.getBoolInput('htmlExtraDarkTheme');
     newman.argIf(htmlExtraDarkTheme, ['--reporter-htmlextra-darkTheme']);
@@ -50,9 +57,9 @@ function GetToolRunner(collectionToRun: string) {
     let htmlExtraReportTitle = tl.getInput('htmlExtraReportTitle');
     newman.argIf(typeof htmlExtraReportTitle != 'undefined' && htmlExtraReportTitle, ['--reporter-htmlextra-title', htmlExtraReportTitle]);
 
-    let reporterJsonExport = tl.getPathInput('reporterJsonExport');
+    let reporterJsonExport = suffixExportPath(tl.getPathInput('reporterJsonExport'), exportSuffix);
     newman.argIf(typeof reporterJsonExport != 'undefined' && tl.filePathSupplied('reporterJsonExport'), ['--reporter-json-export', reporterJsonExport]);
-    let reporterJUnitExport = tl.getPathInput('reporterJUnitExport', false, false);
+    let reporterJUnitExport = suffixExportPath(tl.getPathInput('reporterJUnitExport', false, false), exportSuffix);
     newman.argIf(typeof reporterJUnitExport != 'undefined' && tl.filePathSupplied('reporterJUnitExport'), ['--reporter-junit-export', reporterJUnitExport]);
 
     let verbose = tl.getBoolInput('verbose');
@@ -158,8 +165,10 @@ async function run() {
                 console.log("found %d files", matchedFiles.length);
 
                 if (matchedFiles.length > 0) {
+                    const multipleFiles = matchedFiles.length > 1;
                     matchedFiles.forEach((file: string) => {
-                        var newman: trm.ToolRunner = GetToolRunner(file);
+                        const suffix = multipleFiles ? path.parse(file).name : undefined;
+                        var newman: trm.ToolRunner = GetToolRunner(file, suffix);
                         var execResponse = newman.execSync();
                         // tl.debug(execResponse.stdout);
                         if (execResponse.code === 1) {

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -9,8 +9,8 @@
   "author": "Carlo Wahlstedt",
   "version": {
     "Major": 4,
-    "Minor": 1,
-    "Patch": 2
+    "Minor": 2,
+    "Patch": 0
   },
   "demands": [],
   "groups": [

--- a/Tests/TestSuite.ts
+++ b/Tests/TestSuite.ts
@@ -200,6 +200,16 @@ describe('Normal behavior', function () {
         assert(runner.stdOutContained('--color off'), 'newman should be invoked with --color off');
         assert(!runner.stdOutContained('--no-color'), 'the removed --no-color flag should not be emitted');
     })
+    it('Reporter export paths are suffixed per collection when iterating over a folder', async () => {
+        this.timeout(1000);
+        let testPath = path.join(__dirname, 'multiCollectionReportNamingTest.js');
+        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        await runner.runAsync();
+        assert(runner.succeeded, 'Should be in success');
+        assert(runner.stdOutContained('--reporter-junit-export ' + path.normalize('/out/report-collection1.xml')), 'collection1 export filename is suffixed');
+        assert(runner.stdOutContained('--reporter-junit-export ' + path.normalize('/out/report-collection2.xml')), 'collection2 export filename is suffixed');
+        assert(!runner.stdOutContained('--reporter-junit-export ' + path.normalize('/out/report.xml')), 'the unsuffixed export path should not be emitted when multiple collections match');
+    })
 });
 
 

--- a/Tests/multiCollectionReportNamingTest.ts
+++ b/Tests/multiCollectionReportNamingTest.ts
@@ -1,0 +1,54 @@
+import mockanswer = require('azure-pipelines-task-lib/mock-answer');
+import mockrun = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'NewmanPostman', 'newmantask.js');
+
+let runner: mockrun.TaskMockRunner = new mockrun.TaskMockRunner(taskPath);
+let dirPath = path.normalize('/srcDir/');
+let junitOut = path.normalize('/out/report.xml');
+
+runner.setInput('collectionSourceType', 'file');
+runner.setInput('environmentSourceType', 'none');
+runner.setInput('collectionFileSource', dirPath);
+runner.setInput('Contents', '**/collection1.json\n**/collection2.json');
+runner.setInput('reporters', 'junit');
+runner.setInput('reporterJUnitExport', junitOut);
+
+let answers = <mockanswer.TaskLibAnswers>{
+    'checkPath': {},
+    'which': {
+        'newman': 'newman'
+    },
+    'stats': {},
+    'find': {},
+    'exec': {}
+};
+answers.checkPath[dirPath] = true;
+answers.checkPath['newman'] = true;
+answers.checkPath[junitOut] = true;
+answers.stats[dirPath] = true;
+answers.find[dirPath] = [
+    path.normalize('/srcDir/collection1.json'),
+    path.normalize('/srcDir/collection2.json'),
+];
+
+let suffixed1 = path.join(path.dirname(junitOut), 'report-collection1.xml');
+let suffixed2 = path.join(path.dirname(junitOut), 'report-collection2.xml');
+answers.exec[`newman run ${dirPath}collection1.json --reporter-junit-export ${suffixed1} -r junit`] = { 'code': 0, 'stdout': 'OK' };
+answers.exec[`newman run ${dirPath}collection2.json --reporter-junit-export ${suffixed2} -r junit`] = { 'code': 0, 'stdout': 'OK' };
+
+runner.setAnswers(answers);
+runner.registerMockExport('stats', (itemPath: string) => {
+    switch (itemPath) {
+        case dirPath:
+            return { isDirectory: () => true };
+        case path.normalize('/srcDir/collection1.json'):
+        case path.normalize('/srcDir/collection2.json'):
+            return { isDirectory: () => false };
+        default:
+            throw { code: 'ENOENT' };
+    }
+});
+
+runner.run();

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "NewmanPostman",
-  "version": "3.0.26",
+  "version": "3.1.0",
   "name": "Newman the cli Companion for Postman",
   "scopes": [],
   "description": "Using Newman, one can effortlessly run and test a Postman Collections directly from the command-line. Now in a task! ** Not an official task **",


### PR DESCRIPTION
## Summary

- When `collectionSourceType=file` points at a directory and `Contents` matches more than one collection, the task was invoking newman once per collection but every invocation wrote to the same `reporterHtmlExport` / `reporterHtmlExtraExport` / `reporterJsonExport` / `reporterJUnitExport` path. The final collection's report silently overwrote the rest.
- New `suffixExportPath(p, suffix)` helper in `NewmanPostman/newmantask.ts`. `GetToolRunner` now takes an optional `exportSuffix` and applies it to those four export paths.
- The multi-file loop in `run()` derives the suffix from `path.parse(file).name` only when `matchedFiles.length > 1`. Single-file and URL paths are unchanged.
- `task.json`: 4.1.2 → 4.2.0 (minor — visible behavior change for folder-mode users). `vss-extension.json`: 3.0.26 → 3.1.0.
- New `Tests/multiCollectionReportNamingTest.ts` plus a matching `it()` in the suite — asserts both suffixed paths land in the captured stdout and the unsuffixed path does not.

Closes #102.
Closes #66.
Closes #62 (the existing feature request to name the report after the collection is naturally satisfied by this change in folder mode).

## Test plan

- [x] `npm test` — 21/21 passing on Node 20.
- [x] New scenario asserts both per-collection paths are emitted and the original (unsuffixed) path is not.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_