### PR TITLE
Add workingDir input to forward --working-dir to newman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.3.0 — task / 3.2.0 — extension
+
+### Added
+- New `Working Directory` input (advanced group) that forwards `--working-dir <path>` to newman. Set it when your collection references files via relative paths (e.g. iteration data referenced from a request body) and those files live somewhere other than the agent's current directory. (#104)
+
 ## v4.2.0 — task / 3.1.0 — extension
 
 ### Changed

--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -101,6 +101,9 @@ function GetToolRunner(collectionToRun: string, exportSuffix?: string) {
     let dataFile = tl.getPathInput('dataFile', false, true);
     newman.argIf(typeof globalVariable != 'undefined' && tl.filePathSupplied('dataFile'), ['--iteration-data', dataFile]);
 
+    let workingDir = tl.getPathInput('workingDir', false, true);
+    newman.argIf(typeof workingDir != 'undefined' && tl.filePathSupplied('workingDir'), ['--working-dir', workingDir]);
+
     let folder = tl.getInput('folder');
     if(typeof folder != 'undefined' && folder) {
         const splitted = folder.split(",");

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -9,7 +9,7 @@
   "author": "Carlo Wahlstedt",
   "version": {
     "Major": 4,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "demands": [],
@@ -175,6 +175,15 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Use if your build agent can't find newman automatically and you want to specify the path"
+    },
+    {
+      "name": "workingDir",
+      "type": "filePath",
+      "label": "Working Directory",
+      "defaultValue": "",
+      "required": false,
+      "groupName": "advanced",
+      "helpMarkDown": "Newman's `--working-dir <path>`. Sets the directory used when the collection references files with relative paths (e.g. data files referenced from a request body). Defaults to the agent's current directory."
     },
     {
       "name": "unicodeDisabled",

--- a/Tests/TestSuite.ts
+++ b/Tests/TestSuite.ts
@@ -210,6 +210,14 @@ describe('Normal behavior', function () {
         assert(runner.stdOutContained('--reporter-junit-export ' + path.normalize('/out/report-collection2.xml')), 'collection2 export filename is suffixed');
         assert(!runner.stdOutContained('--reporter-junit-export ' + path.normalize('/out/report.xml')), 'the unsuffixed export path should not be emitted when multiple collections match');
     })
+    it('workingDir input forwards --working-dir to newman', async () => {
+        this.timeout(1000);
+        let testPath = path.join(__dirname, 'workingDirTest.js');
+        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        await runner.runAsync();
+        assert(runner.succeeded, 'Should be in success');
+        assert(runner.stdOutContained('--working-dir ' + path.normalize('/srcDir/data')), 'workingDir is added as arg');
+    })
 });
 
 

--- a/Tests/workingDirTest.ts
+++ b/Tests/workingDirTest.ts
@@ -1,0 +1,32 @@
+import mockanswer = require('azure-pipelines-task-lib/mock-answer');
+import mockrun = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'NewmanPostman', 'newmantask.js');
+
+let runner: mockrun.TaskMockRunner = new mockrun.TaskMockRunner(taskPath);
+let filePath = path.normalize('/srcDir/collection.json');
+let workingDir = path.normalize('/srcDir/data');
+
+runner.setInput('collectionSourceType', 'file');
+runner.setInput('environmentSourceType', 'none');
+runner.setInput('collectionFileSource', filePath);
+runner.setInput('Contents', path.normalize('**/collection.json'));
+runner.setInput('workingDir', workingDir);
+
+let answers = <mockanswer.TaskLibAnswers>{
+    'checkPath': {},
+    'which': {
+        'newman': 'newman'
+    },
+    'stats': {},
+    'exec': {}
+};
+answers.checkPath[filePath] = true;
+answers.checkPath[workingDir] = true;
+answers.checkPath['newman'] = true;
+answers.stats[filePath] = true;
+runner.setAnswers(answers);
+
+answers.exec[`newman run ${filePath} --working-dir ${workingDir}`] = { 'code': 0, 'stdout': 'OK' };
+runner.run();

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "NewmanPostman",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "name": "Newman the cli Companion for Postman",
   "scopes": [],
   "description": "Using Newman, one can effortlessly run and test a Postman Collections directly from the command-line. Now in a task! ** Not an official task **",


### PR DESCRIPTION
## Summary

- New `Working Directory` (`workingDir`) input under the Advanced group in `task.json`. Forwards Newman's `--working-dir <path>` flag, which controls how Newman resolves relative file references inside the collection (e.g. iteration data files referenced from a request body).
- Without it, users have had to either `cd` before the task or duplicate data files into the agent's current directory.
- New `Tests/workingDirTest.ts` plus a matching `it()` in the suite — asserts `--working-dir <path>` is emitted in the captured stdout.
- `task.json`: 4.2.0 → 4.3.0 (minor — new input). `vss-extension.json`: 3.1.0 → 3.2.0.

Closes #104.

## Test plan

- [x] `npm test` — 22/22 passing on Node 20.
- [x] New scenario asserts the new flag is forwarded with the configured path.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_