### PR TITLE
Resolve newman via local node_modules and optional npx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v4.3.1 — task / 3.2.1 — extension
+
+### Added
+- New `Use npx to invoke newman` checkbox (advanced group) — when enabled, the task runs `npx newman` instead of looking up a global `newman` binary. Use this on build agents that disallow global npm installs. (#55)
+- The task now automatically prefers `./node_modules/.bin/newman` (relative to the agent's current directory) when `Path to Newman` is unset, `Use npx` is unchecked, and the local binary exists. Falls through to the global `newman` on PATH if not found. (#105)
+
+The resolution order is: `pathToNewman` → `useNpx` → local `./node_modules/.bin/newman` → global `newman`.
+
 ## v4.3.0 — task / 3.2.0 — extension
 
 ### Added

--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -12,14 +12,27 @@ function suffixExportPath(p: string | undefined, suffix: string | undefined): st
 
 function GetToolRunner(collectionToRun: string, exportSuffix?: string) {
     let pathToNewman = tl.getInput('pathToNewman', false);
+    let useNpx = tl.getBoolInput('useNpx');
+
+    let newman: trm.ToolRunner;
     if (typeof pathToNewman != 'undefined' && pathToNewman) {
         console.info("Specific path to newman found");
+        newman = tl.tool(tl.which(pathToNewman, true));
+    } else if (useNpx) {
+        console.info("useNpx is set, invoking newman via npx");
+        newman = tl.tool(tl.which('npx', true));
+        newman.arg('newman');
     } else {
-        console.info("No specific path to newman, using default of 'newman'");
-        pathToNewman = "newman";
+        let localBin = path.join(process.cwd(), 'node_modules', '.bin',
+            process.platform === 'win32' ? 'newman.cmd' : 'newman');
+        if (tl.exist(localBin)) {
+            console.info(`Using local newman at ${localBin}`);
+            newman = tl.tool(localBin);
+        } else {
+            console.info("No specific path to newman, using default of 'newman'");
+            newman = tl.tool(tl.which('newman', true));
+        }
     }
-
-    var newman: trm.ToolRunner = tl.tool(tl.which(pathToNewman, true));
 
     newman.arg('run');
     newman.arg(collectionToRun);

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 4,
     "Minor": 3,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [
@@ -184,6 +184,15 @@
       "required": false,
       "groupName": "advanced",
       "helpMarkDown": "Newman's `--working-dir <path>`. Sets the directory used when the collection references files with relative paths (e.g. data files referenced from a request body). Defaults to the agent's current directory."
+    },
+    {
+      "name": "useNpx",
+      "type": "boolean",
+      "label": "Use npx to invoke newman",
+      "defaultValue": false,
+      "required": false,
+      "groupName": "advanced",
+      "helpMarkDown": "When enabled, runs `npx newman` instead of looking for newman on the agent. Use this on build agents that disallow global npm installs. If `Path to Newman` is set it takes precedence; otherwise resolution order is: local `./node_modules/.bin/newman` → global `newman` on PATH."
     },
     {
       "name": "unicodeDisabled",

--- a/Tests/TestSuite.ts
+++ b/Tests/TestSuite.ts
@@ -218,6 +218,26 @@ describe('Normal behavior', function () {
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--working-dir ' + path.normalize('/srcDir/data')), 'workingDir is added as arg');
     })
+    it('Local node_modules/.bin/newman is preferred when neither pathToNewman nor useNpx is set', async () => {
+        this.timeout(1000);
+        let testPath = path.join(__dirname, 'localNewmanFallbackTest.js');
+        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        await runner.runAsync();
+        assert(runner.succeeded, 'Should be in success');
+        let localBin = path.join(process.cwd(), 'node_modules', '.bin',
+            process.platform === 'win32' ? 'newman.cmd' : 'newman');
+        assert(runner.stdOutContained('Using local newman at ' + localBin), 'task should log the local newman path');
+        assert(runner.stdOutContained(localBin + ' run'), 'task should invoke the local newman binary');
+    })
+    it('useNpx checkbox runs newman through npx', async () => {
+        this.timeout(1000);
+        let testPath = path.join(__dirname, 'useNpxTest.js');
+        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        await runner.runAsync();
+        assert(runner.succeeded, 'Should be in success');
+        assert(runner.stdOutContained('useNpx is set'), 'task should log that npx was chosen');
+        assert(runner.stdOutContained('npx newman run'), 'task should invoke `npx newman run`');
+    })
 });
 
 

--- a/Tests/localNewmanFallbackTest.ts
+++ b/Tests/localNewmanFallbackTest.ts
@@ -1,0 +1,33 @@
+import mockanswer = require('azure-pipelines-task-lib/mock-answer');
+import mockrun = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'NewmanPostman', 'newmantask.js');
+
+let runner: mockrun.TaskMockRunner = new mockrun.TaskMockRunner(taskPath);
+let filePath = path.normalize('/srcDir/collection.json');
+let localBin = path.join(process.cwd(), 'node_modules', '.bin',
+    process.platform === 'win32' ? 'newman.cmd' : 'newman');
+
+runner.setInput('collectionSourceType', 'file');
+runner.setInput('environmentSourceType', 'none');
+runner.setInput('collectionFileSource', filePath);
+runner.setInput('Contents', path.normalize('**/collection.json'));
+
+let answers = <mockanswer.TaskLibAnswers>{
+    'checkPath': {},
+    'which': {
+        'newman': '/should/not/be/used/newman'
+    },
+    'stats': {},
+    'exist': {},
+    'exec': {}
+};
+answers.checkPath[filePath] = true;
+answers.checkPath['/should/not/be/used/newman'] = true;
+answers.exist[localBin] = true;
+answers.stats[filePath] = true;
+runner.setAnswers(answers);
+
+answers.exec[`${localBin} run ${filePath}`] = { 'code': 0, 'stdout': 'OK' };
+runner.run();

--- a/Tests/useNpxTest.ts
+++ b/Tests/useNpxTest.ts
@@ -1,0 +1,31 @@
+import mockanswer = require('azure-pipelines-task-lib/mock-answer');
+import mockrun = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'NewmanPostman', 'newmantask.js');
+
+let runner: mockrun.TaskMockRunner = new mockrun.TaskMockRunner(taskPath);
+let filePath = path.normalize('/srcDir/collection.json');
+
+runner.setInput('collectionSourceType', 'file');
+runner.setInput('environmentSourceType', 'none');
+runner.setInput('collectionFileSource', filePath);
+runner.setInput('Contents', path.normalize('**/collection.json'));
+runner.setInput('useNpx', 'true');
+
+let answers = <mockanswer.TaskLibAnswers>{
+    'checkPath': {},
+    'which': {
+        'npx': 'npx',
+        'newman': '/should/not/be/used/newman'
+    },
+    'stats': {},
+    'exec': {}
+};
+answers.checkPath[filePath] = true;
+answers.checkPath['npx'] = true;
+answers.stats[filePath] = true;
+runner.setAnswers(answers);
+
+answers.exec[`npx newman run ${filePath}`] = { 'code': 0, 'stdout': 'OK' };
+runner.run();

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "NewmanPostman",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "name": "Newman the cli Companion for Postman",
   "scopes": [],
   "description": "Using Newman, one can effortlessly run and test a Postman Collections directly from the command-line. Now in a task! ** Not an official task **",


### PR DESCRIPTION
## Summary

Adds two new ways to resolve `newman` so the task works on agents that disallow global npm installs:

- **`useNpx`** (new boolean input, advanced group) — when checked, the task invokes `npx newman ...` instead of looking for a global binary. Closes #55.
- **Local `./node_modules/.bin/newman` fallback** — when `pathToNewman` is unset and `useNpx` is off, the task now checks for `node_modules/.bin/newman` under the current working directory and uses it if present. Falls through to the existing `tl.which('newman')` lookup otherwise. Closes #105.

The full resolution chain is now: `pathToNewman` → `useNpx` → local `./node_modules/.bin/newman` → global `newman` on PATH.

Other notes:
- The local-bin check uses `process.cwd()` rather than `tl.cwd()` because `tl.cwd()` is mocked and returns `null` in tests when not explicitly answered.
- Platform-aware filename: `newman.cmd` on Windows, `newman` elsewhere.
- New `Tests/localNewmanFallbackTest.ts` and `Tests/useNpxTest.ts` cover both branches. The local-bin test wires `answers.exist[<localBin>] = true` (the mock framework routes `tl.exist` through `answers.exist`, not `answers.checkPath`).
- `task.json`: 4.3.0 → 4.3.1 (patch — adds a new optional input with backwards-compatible defaults). `vss-extension.json`: 3.2.0 → 3.2.1.

## Test plan

- [x] `npm test` — 24/24 passing on Node 20 (22 existing + 2 new).
- [x] `useNpxTest` asserts `npx newman run ...` is emitted and the npx-selected log line is present.
- [x] `localNewmanFallbackTest` asserts the local-bin path is logged and used in the exec command.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_