### PR TITLE
Raise mocha timeout to 30s to absorb cold-cache Node download

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "compile": "tsc -p .",
     "install-task-lib": "cd NewmanPostman && npm install --save-dev",
     "pretest": "tsc -p .",
-    "test": "npx mocha Tests//TestSuite.js"
+    "test": "npx mocha Tests//TestSuite.js --timeout 30000"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",


### PR DESCRIPTION
## Summary

Adds `--timeout 30000` to the mocha invocation in the root `test` script so the first scenario doesn't trip mocha's 2-second default while the MockTestRunner downloads `node-v16.20.2-linux-x64.tar.gz` on a fresh CI agent.

## Why

The Publish stage on master just failed with:

```
1) Error if collection file path is empty:
   Error: Timeout of 2000ms exceeded.
```

— while every other test passed in ~70-100ms. The first test's slowness is the one-time Node 16 download in `azure-pipelines-task-lib`'s mock runner; once cached the test runs in <200ms.

The suite has per-test `this.timeout(1000)` calls that look like they should help, but they're no-ops: every `it(...)` uses an arrow function, so `this` doesn't bind to mocha's test context. Rather than rewrite the whole suite to non-arrow function syntax, raising the script-level timeout is a one-line surgical fix.

30s is generous — total suite runtime is ~3s normally — but absorbs cold-cache variance comfortably.

## Test plan

- [x] `npm test` locally — 24/24 passing, suite finishes in ~6s.
- [x] Targets the exact failure mode in the failing CI log.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_