### PR TITLE
Cherry-pick Node 24 handler and test-runner fixes from #126

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v4.3.3 — task / 3.2.3 — extension
+
+### Added
+- New `Node24` execution handler in `task.json` alongside the existing `Node20_1`. Agents that support Node 24 will prefer it; older agents fall through to Node 20 with no change in behavior. Sets `minimumAgentVersion: 4.265.1` (required for the Node 24 handler) — self-hosted agents older than that will need to upgrade. (#126)
+
+### Changed
+- TypeScript `compilerOptions.target` raised from ES6 to ES2022. Node 20+ supports the full ES2022 surface natively; output bundle is unchanged for the runtime task but allows newer syntax in future contributions.
+- Test suite refactored: each `it()` now goes through a `makeRunner()` helper that pins `runner.nodePath = process.execPath`. This stops the mock test runner from downloading `node-v16.20.2-linux-x64.tar.gz` on the first test of a cold CI agent — which was the root cause of the flake hot-fixed in v3.2.2. Reverts the `--timeout 30000` mocha flag added then.
+- Defensive catch typing in `newmantask.ts`: `err.message` → `err instanceof Error ? err.message : String(err)`, conforming to TS 5's `unknown` catch parameter.
+- Test script path typo `Tests//TestSuite.js` → `Tests/TestSuite.js`.
+
+Credit to @esbenbach (#126) for the Node 24 handler, the `nodePath` test-runner fix, and the catch-typing pattern.
+
 ## v4.3.2 — task / 3.2.2 — extension
 
 ### Security

--- a/NewmanPostman/newmantask.ts
+++ b/NewmanPostman/newmantask.ts
@@ -218,7 +218,8 @@ async function run() {
             tl.setResult(tl.TaskResult.Failed, "Failed");
         }
     } catch (err) {
-        tl.setResult(tl.TaskResult.Failed, err.message);
+        const message = err instanceof Error ? err.message : String(err);
+        tl.setResult(tl.TaskResult.Failed, message);
     }
 }
 

--- a/NewmanPostman/task.json
+++ b/NewmanPostman/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 4,
     "Minor": 3,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "groups": [
@@ -447,8 +447,12 @@
     }
   ],
   "instanceNameFormat": "Newman - Postman",
+  "minimumAgentVersion": "4.265.1",
   "execution": {
     "Node20_1": {
+      "target": "newmantask.js"
+    },
+    "Node24": {
       "target": "newmantask.js"
     }
   }

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ We thank the following contributor(s) for this extension:
 - [Skiepp](https://github.com/Skiepp)
 - [ch264](https://github.com/ch264)
 - [satano](https://github.com/satano)
+- [jwigert](https://github.com/jwigert)
+- [yossarian123](https://github.com/yossarian123)
 
 ### Feedback
 

--- a/Tests/TestSuite.ts
+++ b/Tests/TestSuite.ts
@@ -2,75 +2,60 @@ import * as mocktest from 'azure-pipelines-task-lib/mock-test';
 import * as path from 'path';
 import * as assert from 'assert';
 
+function makeRunner(scenario: string): mocktest.MockTestRunner {
+    let runner = new mocktest.MockTestRunner(path.join(__dirname, scenario));
+    runner.nodePath = process.execPath;
+    return runner;
+}
+
 describe('Error handling', function () {
     before(() => { });
 
     after(() => { });
 
     it('Error if collection file path is empty', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'emptyCollectionTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('emptyCollectionTest.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         console.log(runner.stderr);
         assert(runner.failed, 'Should be in Failed status');
         assert(runner.stdOutContained('Input required: collectionFileSource'), 'Empty Collection file source should raise an error');
     });
     it('Error if collection is a directory and content not set', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'emptyContents.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('emptyContents.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.failed, 'Should be in Failed status');
         assert(runner.stdOutContained('Input required: Contents'), 'Empty content should raise an error if collection is a directory');
     });
     it('Error if environement is set as a file and none set', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'emptyEnvironmentFile.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('emptyEnvironmentFile.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.failed, 'Should be in Failed status');
         assert(runner.stdOutContained('Input required: environment'), 'Empty environment file should raise an error if envt type is \'file\'');
     });
     it('Error if environement is set as a URL and none set', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'emptyEnvironmentURL.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('emptyEnvironmentURL.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.failed, 'Should be in Failed status');
         assert(runner.stdOutContained('Input required: environmentUrl'), 'Empty url should raise an error if envt type is \'url\'');
-    })
+    });
     it('Error if provided environment url is not a valid url', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'wrongEnvironmentURL.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('wrongEnvironmentURL.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.failed, 'Should be in Failed status');
         assert(runner.stdOutContained('for environment is not a valid url'), 'Error if environement URL format is incorrect');
     });
     it('Error if provided collection url is not a valid url', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'wrongCollectionURL.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('wrongCollectionURL.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.failed, 'Should be in Failed status');
         assert(runner.stdOutContained('for collection is not a valid url'), 'Error if collection URL format is incorrect');
-    })
+    });
     it('Error if no match file in collection directory', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'noMatchedFileInDir.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('noMatchedFileInDir.js');
         await runner.runAsync();
         assert(runner.failed, 'Should be in Failed status');
         assert(runner.stdOutContained('Could not find any collection files in the path provided'), 'Error if collection URL format is incorrect');
-        // assert(runner.errorIssues)
-    })
+    });
 });
 
 
@@ -78,166 +63,116 @@ describe('Normal behavior', function () {
     before(() => { });
 
     after(() => { });
+
     it('Environment is not mandatory', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'noEnvironment.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('noEnvironment.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.succeeded, 'Should in success');
         assert(runner.stdOutContained('No environment set, no need to add it in argument'), 'No error if no envt is set');
-    })
+    });
     it('When a folder is set as source, collection in this dir are used', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'folderAsSource.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('folderAsSource.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
-        assert(runner.succeeded, 'Should be in success')
+        assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('found 2 files'), '2 files are found');
         assert(runner.invokedToolCount == 2, 'should have call n two times. Actual:' + runner.invokedToolCount);
-        assert(runner.stdOutContained('n run /srcDir/collection1.json'), 'Should have used collection1.json');
-        assert(runner.stdOutContained('n run /srcDir/collection2.json'), 'Should have used collection2.json');
-
-    })
+        assert(runner.stdOutContained('n run ' + path.normalize('/srcDir/collection1.json')), 'Should have used collection1.json');
+        assert(runner.stdOutContained('n run ' + path.normalize('/srcDir/collection2.json')), 'Should have used collection2.json');
+    });
     it('When environment file is set, it\'s used', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'useEnvironmentFile.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('useEnvironmentFile.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
-        assert(runner.succeeded, 'Should be in success')
+        assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('-e ' + path.normalize('/srcDir/environment.json')), 'environment file is added as arg');
     });
     it('URL can be set for collection', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'useCollectionURL.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('useCollectionURL.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
-        assert(runner.succeeded, 'Should be in success')
+        assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('run https://api.getpostman.com/collections/4b34e87f2bd3fbbaf1a4'), 'url is used as collection source');
     });
     it('URL can be set for environment', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'useEnvironmentURL.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('useEnvironmentURL.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('-e https://api.getpostman.com/environments?apikey=4b34e87f2bd3fbbaf1a4'), 'url can be used as environment source');
     });
     it('Multiple report format can be set', async () => {
-        this.timeout(1000);
-
-        let testPath = path.join(__dirname, 'customReporterTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('customReporterTest.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('-r cli,json'), 'custom reporter format are set');
     });
-
     it('Number of iteration can be set', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'numberOfIterationTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('numberOfIterationTest.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('-n 2'), 'number of iteration is set');
     });
-
     it('Folder can be set', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'folderTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('folderTest.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--folder /'), 'folder is set');
     });
     it('Global var file can be set', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'globalVarFileTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('globalVarFileTest.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--globals ' + path.normalize('/srcDir/Global.json')), 'folder is set');
     });
     it('Multiple Global vars can be set', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'globalVarTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('globalVarTest.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--global-var var1=1 --global-var var2=2'), 'multiple variables are set');
     });
     it('When path to newman is set, this one is used', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'useNewmanPath.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('useNewmanPath.js');
         await runner.runAsync();
-        // console.error(runner.stdout);
         assert(runner.succeeded, 'Should be in success');
-    })
+    });
     it('htmlExtra template path is forwarded to newman with the correct flag', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'htmlExtraTemplateTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('htmlExtraTemplateTest.js');
         await runner.runAsync();
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--reporter-htmlextra-template ' + path.normalize('/srcDir/htmlExtra.hbs')), 'htmlextra template is added as arg');
-    })
+    });
     it('forceNoColor input forwards the supported --color off flag', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'forceNoColorTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('forceNoColorTest.js');
         await runner.runAsync();
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--color off'), 'newman should be invoked with --color off');
         assert(!runner.stdOutContained('--no-color'), 'the removed --no-color flag should not be emitted');
-    })
+    });
     it('Reporter export paths are suffixed per collection when iterating over a folder', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'multiCollectionReportNamingTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('multiCollectionReportNamingTest.js');
         await runner.runAsync();
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--reporter-junit-export ' + path.normalize('/out/report-collection1.xml')), 'collection1 export filename is suffixed');
         assert(runner.stdOutContained('--reporter-junit-export ' + path.normalize('/out/report-collection2.xml')), 'collection2 export filename is suffixed');
         assert(!runner.stdOutContained('--reporter-junit-export ' + path.normalize('/out/report.xml')), 'the unsuffixed export path should not be emitted when multiple collections match');
-    })
+    });
     it('workingDir input forwards --working-dir to newman', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'workingDirTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('workingDirTest.js');
         await runner.runAsync();
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('--working-dir ' + path.normalize('/srcDir/data')), 'workingDir is added as arg');
-    })
+    });
     it('Local node_modules/.bin/newman is preferred when neither pathToNewman nor useNpx is set', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'localNewmanFallbackTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('localNewmanFallbackTest.js');
         await runner.runAsync();
         assert(runner.succeeded, 'Should be in success');
         let localBin = path.join(process.cwd(), 'node_modules', '.bin',
             process.platform === 'win32' ? 'newman.cmd' : 'newman');
         assert(runner.stdOutContained('Using local newman at ' + localBin), 'task should log the local newman path');
         assert(runner.stdOutContained(localBin + ' run'), 'task should invoke the local newman binary');
-    })
+    });
     it('useNpx checkbox runs newman through npx', async () => {
-        this.timeout(1000);
-        let testPath = path.join(__dirname, 'useNpxTest.js');
-        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        let runner = makeRunner('useNpxTest.js');
         await runner.runAsync();
         assert(runner.succeeded, 'Should be in success');
         assert(runner.stdOutContained('useNpx is set'), 'task should log that npx was chosen');
         assert(runner.stdOutContained('npx newman run'), 'task should invoke `npx newman run`');
-    })
+    });
 });
-
-

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "compile": "tsc -p .",
     "install-task-lib": "cd NewmanPostman && npm install --save-dev",
     "pretest": "tsc -p .",
-    "test": "npx mocha Tests//TestSuite.js --timeout 30000"
+    "test": "npx mocha Tests/TestSuite.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2022",
     "module": "commonjs"
   },
   "exclude": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "NewmanPostman",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "name": "Newman the cli Companion for Postman",
   "scopes": [],
   "description": "Using Newman, one can effortlessly run and test a Postman Collections directly from the command-line. Now in a task! ** Not an official task **",


### PR DESCRIPTION
## Summary

Cherry-picks the additive, low-risk pieces of @esbenbach's #126 on top of master's current state (which has since absorbed the Node 20 migration, security overrides PR #137, and the test-timeout hotfix PR #136).

**Included from #126:**

| Change | Why now |
| --- | --- |
| `task.json`: add `Node24` handler alongside `Node20_1`, set `minimumAgentVersion: 4.265.1` | Future-proofing. Agents that support Node 24 prefer it; older agents fall through to Node 20 with no behavior change. **Heads-up:** self-hosted agents older than 4.265.1 will need an agent upgrade — hosted agents are well past that threshold. |
| `tsconfig.json`: `target: ES6` → `ES2022` | Node 20+ supports the full ES2022 surface natively. |
| `newmantask.ts` catch block: defensive `err instanceof Error ? err.message : String(err)` | Conforms to TS 5's `unknown` catch typing. |
| `Tests/TestSuite.ts`: new `makeRunner()` helper that sets `runner.nodePath = process.execPath` | **Root-cause fix for the cold-cache flake hotfixed in v3.2.2.** Stops the mock test runner from downloading `node-v16.20.2-linux-x64.tar.gz` on a fresh CI agent — suite now finishes in ~2s vs ~6s. Also drops the no-op `this.timeout(1000)` calls and normalizes the `folderAsSource` assertion paths. |
| `package.json`: drop `--timeout 30000` and fix `Tests//TestSuite.js` typo | The timeout is no longer needed once `nodePath` is pinned; the path was a long-standing double-slash typo. |

**README housekeeping** (caught during contributor review):

| Change | Why |
| --- | --- |
| Add `jwigert` (Johan Wigert) and `yossarian123` to the Contributors list | Both have merged commits on master (PRs #79 and #64) but were missing from the README. `esbenbach` was already listed, so the credit for #126/#138 was already covered. |

**Deliberately skipped from #126** (would conflict with current master):

- Runtime `azure-pipelines-task-lib` v4 → v5 in `NewmanPostman/` — keeping v4 because the security overrides PR #137 was designed around its transitive tree, and v4 is still supported. Re-opening this would re-litigate the audit posture in maintenance mode.
- `@types/node` ^20 → ^24, mocha ^10 → ^11 — already handled by the override approach; not needed.
- `package-lock.json` rewrites — would regenerate fresh anyway.

## Test plan

- [x] `npm test` — 24/24 passing on Node 20, **2s total** (previously 4–6s with the Node 16 download).
- [x] Manually verified `runner.nodePath` is set to the current process Node binary, eliminating the cold-cache download.
- [x] `task.json` validates as JSON with both handlers declared.

## Credit

Co-authored-by: @esbenbach — the Node 24 handler, the `nodePath` fix, and the catch-typing pattern are all from #126. Will close #126 with a thank-you comment after this lands.

`task.json`: 4.3.2 → 4.3.3 (patch). `vss-extension.json`: 3.2.2 → 3.2.3.

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg