### PR TITLE
Make CI and PR triggers explicit in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,13 @@
+trigger:
+  branches:
+    include:
+      - master
+
+pr:
+  branches:
+    include:
+      - master
+
 resources:
 - repo: self
   clean: true


### PR DESCRIPTION
## Summary

Adds explicit `trigger:` and `pr:` blocks to `azure-pipelines.yml`, both scoped to `master`.

Before this change, the YAML omitted both, so Azure DevOps relied entirely on UI-configured triggers. That meant:
- Reading the repo didn't tell you what should kick off a build
- Trigger config could drift silently if the GitHub-side service connection was rotated (the suspected root cause of PR #138 not firing CI after the v3.2.2 marketplace release fixed the `GitHubRelease@1` "Bad credentials" error)

With the blocks present, Azure DevOps treats the YAML triggers as the source of truth: pushes to `master` fire the Build stage (which gates the Publish stage via its existing branch condition), and PRs targeting `master` fire validation builds. Future service-connection rotations won't silently disable triggers.

## Behavior change

Pushes to feature branches will no longer fire the Build stage directly. They're already covered by the PR validation path — the existing pattern in every PR this session has been "open PR → CI fires → review → merge," so this matches the realistic intent and stops wasting build minutes on unmerged work-in-progress pushes.

If anyone has a workflow that depends on bare branch pushes (without a PR) triggering builds, holler before merging.

## Test plan

- [ ] CI fires when this PR is opened (validates the `pr:` block — if it doesn't fire, the trigger-webhook issue is upstream and needs the UI fix first)
- [ ] After merge, the next push to `master` fires Build + Publish as before

No version bump (`task.json` / `vss-extension.json` untouched — this is purely pipeline configuration).

https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDJVh54xmU3q8HYSMNTtsg)_